### PR TITLE
fixed missing libcrypto dependency for gdal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,9 @@ RUN set -ex \
         make \
         perl \
     \
+    && apk add --no-cache --virtual .gdal-rundeps \
+        --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
+        libressl2.7-libcrypto \
     && apk add --no-cache --virtual .build-deps-testing \
         --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
         gdal-dev \


### PR DESCRIPTION
Hi,

Build failed for me, because gdal was missing libcrypto:

```
+ apk add --no-cache --virtual .build-deps-testing --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing gdal-dev geos-dev proj4-dev
fetch http://dl-cdn.alpinelinux.org/alpine/edge/testing/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.7/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.7/community/x86_64/APKINDEX.tar.gz
WARNING: This apk-tools is OLD! Some packages might not function properly.
ERROR: unsatisfiable constraints:
  so:libcrypto.so.43 (missing):
    required by:
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
                 gdal-2.3.1-r0[so:libcrypto.so.43]
  .build-deps-testing-0:
    masked in: cache
    satisfies: world[.build-deps-testing]
The command '/bin/sh -c set -ex         && apk add --no-cache --virtual .fetch-deps         ca-certificates         openssl         tar         && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/$POSTGIS_VERSION.tar.gz"     && echo "$POSTGIS_SHA256 *postgis.tar.gz" | sha256sum -c -     && mkdir -p /usr/src/postgis     && tar         --extract         --file postgis.tar.gz         --directory /usr/src/postgis         --strip-components 1     && rm postgis.tar.gz         && apk add --no-cache --virtual .build-deps         autoconf         automake         g++         json-c-dev         libtool         libxml2-dev         make         perl         && apk add --no-cache --virtual .build-deps-testing         --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing         gdal-dev         geos-dev         proj4-dev     && cd /usr/src/postgis     && ./autogen.sh     && ./configure     && make     && make install     && apk add --no-cache --virtual .postgis-rundeps         json-c     && apk add --no-cache --virtual .postgis-rundeps-testing         --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing         geos         gdal         proj4     && cd /     && rm -rf /usr/src/postgis     && apk del .fetch-deps .build-deps .build-deps-testing' returned a non-zero code: 4

```

This PR adds the missing dependency.

Cheers,
Marek